### PR TITLE
Fix checkers piece selection

### DIFF
--- a/game.js
+++ b/game.js
@@ -112,8 +112,10 @@ function findAllJumpMoves() {
 
 function handleSquareClick(e) {
   if (gameState.isGameOver) return;
-  const row = parseInt(e.target.dataset.row);
-  const col = parseInt(e.target.dataset.col);
+  const square = e.target.closest('.square');
+  if (!square) return;
+  const row = parseInt(square.dataset.row);
+  const col = parseInt(square.dataset.col);
   if (isNaN(row) || isNaN(col)) return;
 
   // if clicking on own piece


### PR DESCRIPTION
## Summary
- handle clicks on the piece element by resolving to the nearest `.square`

## Testing
- `node check_init.js` (board renders without errors)

------
https://chatgpt.com/codex/tasks/task_e_68447b2a7a3c8326bfaca0d7cf4342c2